### PR TITLE
Fix: make output of 'Iter_ground' right-canonical

### DIFF
--- a/General functions/Ground state search/Iter_ground.m
+++ b/General functions/Ground state search/Iter_ground.m
@@ -77,5 +77,6 @@ while not_eigenstateness > tol && criterion < 0.8
     
 end
 
+MPS{1} = R_can{MPS,1);
 ground_MPS = MPS;
 end


### PR DESCRIPTION
At the end of the routine the 1st element in the MPS will now be right-canonized